### PR TITLE
Configure Vite server allowed hosts for CodeSandbox

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.proxy.csb.app']
+  }
 })


### PR DESCRIPTION
## Summary
- configure the Vite dev server to allow connections from the .proxy.csb.app domain and listen on all interfaces

## Testing
- `npm run build` *(fails: existing project misconfiguration prevents resolving /src/main.jsx from index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd169788083258d330f40c66b6781